### PR TITLE
Make it possible to suppress error message about stylish-haskell absent in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ time they are saved. It assumes stylish-haskell is accessible from your $PATH.
 If this isn't the case, set the `g:stylish_haskell_command` variable to the
 location of the stylish-haskell binary.
 
+In case `stylish-haskell` is not present in PATH all the time, annoying error
+messages could be suppressed via `g:stylish_haskell_disable_if_not_in_path = 1`.
+
 [stylish-haskell]: https://github.com/jaspervdj/stylish-haskell
 
 Installation

--- a/ftplugin/haskell/stylish-haskell.vim
+++ b/ftplugin/haskell/stylish-haskell.vim
@@ -2,6 +2,10 @@ if !exists("g:stylish_haskell_command")
   let g:stylish_haskell_command = "stylish-haskell"
 endif
 
+if !exists("g:stylish_haskell_disable_if_not_in_path")
+  let g:stylish_haskell_disable_if_not_in_path = 0
+endif
+
 function! s:OverwriteBuffer(output)
   let winview = winsaveview()
   silent! undojoin
@@ -26,5 +30,7 @@ endfunction
 
 augroup stylish-haskell
   autocmd!
-  autocmd BufWritePost *.hs call s:StylishHaskell()
+  if ((executable(g:stylish_haskell_command)) || (!g:stylish_haskell_disable_if_not_in_path))
+    autocmd BufWritePost *.hs call s:StylishHaskell()
+  endif
 augroup END


### PR DESCRIPTION
For some reasons it's a very common situation that `stylish-haskell` binary is not presented in a `PATH` for all the time.

As a user of this plugin it will be nice to have a possibility to turn off these annoying messages about `stylish-haskell` absence in `PATH`. By default this functionality is disabled.