### PR TITLE
Run stylish-haskell from the buffer file directory

### DIFF
--- a/ftplugin/haskell/stylish-haskell.vim
+++ b/ftplugin/haskell/stylish-haskell.vim
@@ -21,7 +21,8 @@ function! s:StylishHaskell()
 endfunction
 
 function! s:RunStylishHaskell()
-  let output = system(g:stylish_haskell_command . " " . bufname("%"))
+  let command = "(cd " . expand("%:h") . "; " . g:stylish_haskell_command . " " . expand("%:p") . ")"
+  let output = system(command)
   let errors = matchstr(output, '\(Language\.Haskell\.Stylish\.Parse\.parseModule:[^\x0]*\)')
   if v:shell_error != 0
     echom output


### PR DESCRIPTION
With multiple projects and a single vim instance, we can have many
.stylish-haskell.yaml files: one for each project.

.
├── client
│   ├── client.cabal
│   ├── LICENSE
│   ├── Setup.hs
│   ├── src
│   │   ├── Main.hs
│   │   └── View.hs
│   └── .stylish-haskell.yaml
└── server
    ├── LICENSE
    ├── server.cabal
    ├── Setup.hs
    ├── src
    │   ├── Main.hs
    │   └── Routes.hs
    └── .stylish-haskell.yaml

Without the `set autochdir` vim option [1], the per-project
.stylish-haskell.yaml files are not used.

This commit transforms the command from `stylish-haskell file.hs` to
`(cd file-directory; stylish-haskell absolute-file.hs)` in order to use
.stylish-haskell.yaml configuration files written in sub-directories.

We augment here the available configuration files, without breaking
actual setups because of the point 3:

“It tries to find a config file in the following order:

1. A file passed to the tool using the `-c/--config` argument
2. `.stylish-haskell.yaml` in the current directory (useful for per-directory settings)
3. `.stylish-haskell.yaml` in the nearest ancestor directory (useful for per-project settings)
4. `.stylish-haskell.yaml` in your home directory (useful for user-wide settings)
5. The default settings.” [2]

Is this modification interesting, since one could use `set autochdir` ?
It may cause some caveats to use this option though. [3]

[1] http://vim.wikia.com/wiki/Set_working_directory_to_the_current_file
[2] https://github.com/jaspervdj/stylish-haskell
[3] https://stackoverflow.com/questions/27183726/autochdir-and-nerdtree