### PR TITLE
Allow for passing options to stylish-haskell

### DIFF
--- a/ftplugin/haskell/stylish-haskell.vim
+++ b/ftplugin/haskell/stylish-haskell.vim
@@ -1,6 +1,9 @@
 if !exists("g:stylish_haskell_command")
   let g:stylish_haskell_command = "stylish-haskell"
 endif
+if !exists("g:stylish_haskell_options")
+  let g:stylish_haskell_options = [ ]
+endif
 
 function! s:OverwriteBuffer(output)
   let winview = winsaveview()
@@ -21,7 +24,7 @@ function! s:StylishHaskell()
 endfunction
 
 function! s:RunStylishHaskell()
-  let output = system(g:stylish_haskell_command . " " . bufname("%"))
+  let output = system(g:stylish_haskell_command . " " . join(g:stylish_haskell_options, ' ') . " " . bufname("%"))
   let errors = matchstr(output, '\(Language\.Haskell\.Stylish\.Parse\.parseModule:[^\x0]*\)')
   if v:shell_error != 0
     echom output


### PR DESCRIPTION
This adds a global variable g:stylish_haskell_options to which arguments to g:stylish_haskell_command can be passed as a list of strings, which is expanded in the output.

Among other things, this can be used to easily invoke stylish-haskell from stack, rather than by providing the path to a stylish-haskell executable.