### PR TITLE
Remove trailing newline when displaying output

### DIFF
--- a/ftplugin/haskell/stylish-haskell.vim
+++ b/ftplugin/haskell/stylish-haskell.vim
@@ -32,7 +32,7 @@ function! s:RunStylishHaskell()
   let output = system(g:stylish_haskell_command . " " . join(g:stylish_haskell_options, ' ') . " " . bufname("%"))
   let errors = matchstr(output, '\(Language\.Haskell\.Stylish\.Parse\.parseModule:[^\x0]*\)')
   if v:shell_error != 0
-    echom output
+    echom substitute(output, '\n$', '', '')
   elseif empty(errors)
     call s:OverwriteBuffer(output)
     write


### PR DESCRIPTION
The trailing newline from the `system()` call is displayed as `^@` by `echom`. This `substitute` removes this trailing newline for cleaner output.

For example, when `stylish-haskell` gives the error
```
exe/Main.hs: <string>:6:8: error: parse error on input `ontrol'
```
this is currently shown by `vim-stylish-haskell` using `echom` as
```
exe/Main.hs: <string>:6:8: error: parse error on input `ontrol'^@
```

(Also see [this somewhat relevant superuser Stack Exchange answer](https://superuser.com/a/935622).)